### PR TITLE
Bug in read_root_page

### DIFF
--- a/src/ulog_sqlite.c
+++ b/src/ulog_sqlite.c
@@ -1279,7 +1279,7 @@ uint32_t read_rowid_at(struct dblog_read_context *rctx, uint32_t rec_pos) {
 
 int read_root_page_no(struct dblog_read_context *rctx, int32_t page_size) {
   if (rctx->root_page)
-    return rctx->root_page;
+    return DBLOG_RES_OK; // do nothing, we already have root_page
   int res = read_bytes_rctx(rctx, rctx->buf, 0, page_size);
   if (res)
     return res;


### PR DESCRIPTION
I am quite certain that this is a bug. This method should return only error defines, but in this case, it returns rctx->root_page.
If i am correct, this check is there just to not repeated determination of root page - in case that it was done before.

In my project (cubesat - small satellite) it fixed behaviour and what i needed.