### PR TITLE
fix for underflow when database is empty

### DIFF
--- a/src/ulog_sqlite.c
+++ b/src/ulog_sqlite.c
@@ -347,6 +347,10 @@ int check_sums(byte *buf, int32_t page_size, int calc_or_check) {
     while (i < end) // Header checksum
       chk_sum += buf[i++];
     uint16_t last_pos = read_uint16(buf + 5);
+    if (last_pos < 3)
+    {
+      return DBLOG_RES_OK; // DB is ok but it is just empty. Prevent underflows further
+    }
     i = last_pos;
     end = i + LEN_OF_REC_LEN;
     read_vint32(buf + end, &vlen);


### PR DESCRIPTION
Hello,
during testing of the code i got some memory leaks and i traced down to the following problem:
- create database with dblog_write_init_with_script()
- do NOT append any data (which we normally do in our project), do nothing
- call dblog_finalize()

in dblog_finalize, underflow of write context buffer`wctx.buf` happens - because the stored length in crc calculation is 0 so the some resulting crc is stored on memory address just before the buffer, corrupting preceding data structures.

I created this hotfix, but i am not sure about consequences or if the "empty" database can cause other problems elsewhere.
Please look into that and let me know.

Best regards
Zbyšek Zapadlík